### PR TITLE
[minor] Allow `uri` to a function for async resolving of URL's

### DIFF
--- a/packages/provider/README.md
+++ b/packages/provider/README.md
@@ -117,6 +117,24 @@ In addition to that it's recommended that this file is served with `text/plain`
 as `Content-Type`. This [prevents a CORS preflight][CORS] request from being
 made and therefor drastically improving performance.
 
+The `uri` property can either be a string or a function. In case of a function
+it will be called with a completion function incase you need to asynchronously
+resolve the URL.
+
+```js
+function resolve(next) {
+  asynctask(function (err, data) {
+    if (err) return next(err);
+
+    next(null, data.url);
+  });
+}
+
+<Provider uri={ resolve }>
+  // ...
+</Provider>
+```
+
 #### preload
 
 Force the provider to automatically start downloading the bundle once the

--- a/packages/provider/asset/index.js
+++ b/packages/provider/asset/index.js
@@ -7,14 +7,26 @@ import { Rect } from 'svgs';
 import rip from 'rip-out';
 
 /**
+ * We don't want a pure number, a string value that represents a number
+ * is fine as well
+ *
+ * @type {PropTypes}
+ * @private
+ */
+const numeric = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.number
+]).isRequired;
+
+/**
  * Validation of the props.
  *
  * @type {Object}
  * @private
  */
 const propTypes = {
-  height: PropTypes.number.isRequired,
-  width: PropTypes.number.isRequired,
+  height: numeric,
+  width: numeric,
   children: PropTypes.element,
   onLoadStart: PropTypes.func,
   onLoadEnd: PropTypes.func,

--- a/packages/provider/test/index.test.js
+++ b/packages/provider/test/index.test.js
@@ -56,6 +56,27 @@ describe('Asset Provider', function () {
     }, 100);
   });
 
+  it('correctly resolves the `uri` function', function (next) {
+    function uri(resolved) {
+      setTimeout(function () {
+        resolved(null, 'http://example.com/complex/bundle.svgs');
+      }, 10);
+    }
+
+    const wrapper = mount(
+      <Provider uri={ uri }>
+        <Asset name='complex' height='100' width='100' />
+      </Provider>
+    );
+
+    setTimeout(function () {
+      const html = wrapper.html();
+      complex(html);
+
+      next();
+    }, 100);
+  })
+
   it('renders through nested context', function (next) {
     const wrapper = mount(
       <div>

--- a/packages/provider/wrapper/index.js
+++ b/packages/provider/wrapper/index.js
@@ -36,6 +36,18 @@ export default function SvgWrapper(props) {
 }
 
 /**
+ * We don't want a pure number, a string value that represents a number
+ * is fine as well
+ *
+ * @type {PropTypes}
+ * @private
+ */
+const numeric = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.number
+]).isRequired;
+
+/**
  * Force validation for some default properties that will be required to render
  * assets.
  *
@@ -46,8 +58,8 @@ export default function SvgWrapper(props) {
  * @private
  */
 SvgWrapper.propTypes = {
-  width: PropTypes.number.isRequired,
-  height: PropTypes.number.isRequired,
+  width: numeric,
+  height: numeric,
   viewBox: PropTypes.string,
   children: PropTypes.element,
   title: PropTypes.string


### PR DESCRIPTION
This introduces the ability to dynamically specify the URL of the provider. While this functionality could be implemented in userland by fetching the URL and then rendering a `<Provider>` it would mean that none of the content would be visible if you wrap your whole application, or that you need to have conditional logic to include the `<Asset />` components in your application both are not ideal and this tiny addition will make it that much easier. 

This patch also includes some quality of life fixes. The `height` and `width` can now also be specified as a string allowing for a more natural syntax:

```js
<Asset name='foo' height='100' width="150" />
```