### PR TITLE
[fix] Set the correct `this` value for the `url` prop when it's used as function

### DIFF
--- a/packages/provider/provider/index.js
+++ b/packages/provider/provider/index.js
@@ -93,7 +93,7 @@ export default class Provider extends Component {
       });
     }
 
-    uri((err, url) => {
+    uri.call(this, (err, url) => {
       if (err) return fn(err);
 
       this.setState({ url }, () => {

--- a/packages/provider/test/provider.test.js
+++ b/packages/provider/test/provider.test.js
@@ -77,6 +77,26 @@ describe('Provider', function () {
       provider.fetch(() => {});
     });
 
+    it('executes props.url function in the same context as the component', function (next) {
+      function uri(done) {
+        done(null, 'http://example.com/500');
+
+        assume(this.props).is.a('object');
+        assume(this).equals(provider);
+
+        next();
+      }
+
+      wrapper = shallow(
+        <Provider uri={ uri } parser={ parser }>
+        <Asset name='example' width='100' height='100' />
+        </Provider>
+      );
+
+      provider = wrapper.instance();
+      provider.fetch(() => {});
+    });
+
     it('only calls props.url once to prevent multiple async URL lookups', function (next) {
       function uri(done) {
         assume(done).is.a('function');


### PR DESCRIPTION
Minor fix to the functionality that I introduced in #5, when the function is executed, it doesn't have access to the `this` value of the component, so it cannot use props, or state, to determine a given URL dynamically. 