### PR TITLE
[fix] Follow {main,index,react-native,module} pattern for exports

### DIFF
--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -2,8 +2,10 @@
   "name": "asset-bundle",
   "version": "2.0.0",
   "description": "Build process that transforms (multiple) SVG assets into a asset-parser compatible bundle",
-  "main": "lib/",
-  "browser": "./index",
+  "main": "./lib",
+  "browser": "./lib",
+  "module": "./index",
+  "react-native": "./index",
   "scripts": {
     "test:web": "mocha --colors --require babel-register test/*.test.js",
     "test": "npm run build && nyc --reporter=text --reporter=lcov npm run test:web",

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -2,8 +2,10 @@
   "name": "asset-list",
   "version": "1.0.1",
   "description": "Automatically generate documentation for your generated asset-bundle's",
-  "main": "lib/",
-  "browser": "./index",
+  "main": "./lib",
+  "browser": "./lib",
+  "module": "./index",
+  "react-native": "./index",
   "scripts": {
     "test:web": "mocha --colors --require babel-register test/*.test.js",
     "test": "nyc --reporter=text --reporter=lcov npm run test:web",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -2,8 +2,10 @@
   "name": "asset-parser",
   "version": "2.0.0",
   "description": "Parse SVG asset bundles",
-  "main": "./lib/",
-  "browser": "./index",
+  "main": "./lib",
+  "browser": "./lib",
+  "module": "./index",
+  "react-native": "./index",
   "scripts": {
     "test:web": "mocha --colors --require babel-register --require test/setup.js test/*.test.js",
     "test": "nyc --reporter=text --reporter=lcov npm run test:web",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -2,8 +2,10 @@
   "name": "asset-provider",
   "version": "3.0.0",
   "description": "Provides the SVG assets through React Context",
-  "main": "lib/",
-  "browser": "./index",
+  "main": "./lib",
+  "browser": "./lib",
+  "module": "./index",
+  "react-native": "./index",
   "scripts": {
     "test:web": "mocha --colors --require babel-register --require test/setup.js test/*.test.js",
     "test": "nyc --reporter=text --reporter=lcov npm run test:web",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -2,8 +2,10 @@
   "name": "asset-webpack",
   "version": "1.0.0",
   "description": "asset-bundle integration for WebPack",
-  "main": "lib/",
-  "browser": "./index",
+  "main": "./lib",
+  "browser": "./lib",
+  "module": "./index",
+  "react-native": "./index",
   "scripts": {
     "test:web": "mocha --colors --require babel-register test/*.test.js",
     "test": "npm run build && nyc --reporter=text --reporter=lcov npm run test:web",


### PR DESCRIPTION
- ReactNative uses uncompile index
- Module points to uncompiled code
- index points to compiled for node
- browser points to compiled for browser