### PR TITLE
Bunch of changes required to make it work with Next.js

### DIFF
--- a/packages/provider/provider/remote.js
+++ b/packages/provider/provider/remote.js
@@ -13,10 +13,9 @@ const debug = diagnostics('asset:provider:remote');
  * @constructor
  * @public
  */
-export default class Remote extends Queue {
+export default class Remote {
   constructor() {
-    super();
-
+    this.queue = new Queue();
     this.cache = {};
   }
 
@@ -32,7 +31,7 @@ export default class Remote extends Queue {
    */
   fetch(options, parser, fn) {
     const { method, uri, format, timeout } = options;
-    const id = this.id(method, uri);
+    const id = this.queue.id(method, uri);
     const item = this.cache[id];
 
     //
@@ -44,7 +43,7 @@ export default class Remote extends Queue {
       return fn(null, item);
     }
 
-    if (this.add(method, uri, fn)) {
+    if (this.queue.add(method, uri, fn)) {
       debug(`the requested uri(${uri}) was already requested, waiting for callback`);
       return true;
     }
@@ -67,7 +66,7 @@ export default class Remote extends Queue {
       // important for native devices!
       //
       if (!error) this.cache[id] = svgs;
-      this.run(method, uri, error, svgs);
+      this.queue.run(method, uri, error, svgs);
     };
 
     debug(`first time requesting uri(${uri})`);

--- a/packages/provider/test/remote.test.js
+++ b/packages/provider/test/remote.test.js
@@ -30,7 +30,7 @@ describe('Remote', function () {
 
   describe('#fetch', function () {
     it('returns items from cache', function (next) {
-      const item = remote.id(method, uri);
+      const item = remote.queue.id(method, uri);
       const mock = { hello: 'world' };
 
       remote.cache[item] = mock;
@@ -44,7 +44,7 @@ describe('Remote', function () {
     });
 
     it('returns `undefined` when a response is cached', function () {
-      const item = remote.id(method, uri);
+      const item = remote.queue.id(method, uri);
       const mock = { hello: 'world' };
 
       remote.cache[item] = mock;
@@ -118,7 +118,7 @@ describe('Remote', function () {
     });
 
     it('caches the correctly parsed data', function (next) {
-      const item = remote.id(method, uri);
+      const item = remote.queue.id(method, uri);
       const mock = { hello: 'world' };
 
       assume(remote.cache).is.length(0);

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -70,6 +70,7 @@ supported:
 
 - `namespace` Should we use the folder structure of the assets as namespaces,
   defaults to `false`.
+- `root` Location of the root directory that used to generate the namespaces.
 - `bundler` Options that will be passed in to the `asset-bundle` constructor.
 - `modify` An object where the key is the name of the modifer and the value the
   function that does the modification. This will be passed in to `bundle#modify`.

--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -161,7 +161,7 @@ class WebPack {
           if (err) throw err;
 
           const hash = this.hash(contents);
-          const filename = compilation.getPath(this.name, {});
+          const filename = compilation.getPath(hash, {});
 
           //
           // Register the new asset.

--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -4,6 +4,20 @@ import async from 'async';
 import path from 'path';
 
 /**
+ * Get the name of the file that required this module, so we can attempt to
+ * resolve a sensible default root directory for the plugin.
+ *
+ * @type {String}
+ * @private
+ */
+var requiredRoot = module.parent && module.parent.filename;
+delete require.cache[__filename];
+
+if (!requiredRoot || !~requiredRoot.indexOf('webpack.config.js')) {
+  requiredRoot = process.cwd();
+}
+
+/**
  * WebPack wrapper for the asset-bundle module.
  *
  * @constructor
@@ -24,7 +38,7 @@ class WebPack {
    * @returns {String} The filename.
    * @private
    */
-  filename(contents) {
+  hash(contents) {
     if (!~this.name.indexOf('[')) return this.name;
 
     const hash = createHash('md5');
@@ -43,10 +57,9 @@ class WebPack {
     compiler.plugin('this-compilation', (compilation) => {
       const options = compilation.options;
       const output = options.output.path;
-      const entry = options.entry;
 
       compilation.plugin('optimize-assets', (assets, next) => {
-        const { plugins, namespace, bundler, modify } = this.options;
+        const { plugins, namespace, bundler, modify, root } = this.options;
         const files = [];
 
         //
@@ -55,7 +68,7 @@ class WebPack {
         // steps our selfs as we don't have the assets yet.
         //
         const bundle = new Bundle([], {
-          root: namespace ? path.dirname(entry) : null,
+          root: namespace ? path.dirname(root || requiredRoot) : null,
           ...(bundler || {})
         });
 
@@ -115,16 +128,23 @@ class WebPack {
           // source. If this breaks, it's most likely this, good luck
           // fixing it brave soul that reads this.
           //
-          // Worth noting, removing the __webpack_public_path__ ref from
-          // exports seem to kill the whole source replacement ¯\_(ツ)_/¯
+          // 1. Removing the __webpack_public_path__ will break the build;
+          // 2. Multi line code will break the build;
+          // 3. Not doing a module.exports = __webpack_public_path__ breaks;
+          // 4. As __webpack_public_path__ can be set, we cant use `? x : y`
+          // 5. As __webpack_public_path__ can be "" we cant `x && y`;
+          // 6. We can't even wrap it in () to create: module.exports (__wpp_, y);
           //
-          module._source._value = `module.exports = __webpack_public_path__ + ${JSON.stringify(name)};`;
-          module.parser.parse(module._source.source(), {
-            current: module,
-            compilation,
-            options,
-            module
-          });
+          // However, doing a double override of the `module.exports` does work
+          // this means we only have to store the (potentially long) name of
+          // the asset once in the new source of the require.
+          //
+          // Have mercy on the brave soul that will ever have to debug this
+          // madness.
+          //
+          // Days wasted by this webpack bullshit: 2
+          //
+          module._source._value = 'module.exports = __webpack_public_path__; module.exports =' + JSON.stringify(name);
         });
 
         //
@@ -140,7 +160,8 @@ class WebPack {
         ], (err, contents) => {
           if (err) throw err;
 
-          const filename = this.filename(contents);
+          const hash = this.hash(contents);
+          const filename = compilation.getPath(this.name, {});
 
           //
           // Register the new asset.

--- a/test/fixtures/entry.js
+++ b/test/fixtures/entry.js
@@ -1,3 +1,3 @@
-require('./godaddy.svg');
-require('./tiger.svg');
-require('./deeper/homer.svg');
+global.godaddy = require('./godaddy.svg');
+global.tiger = require('./tiger.svg');
+global.homer = require('./deeper/homer.svg');


### PR DESCRIPTION
### provider

It was complaining about `Queue` being initialized without `new`, not sure how that is possible, but by simplifying the code the error went away.


### webpack

The transformation of the import was broken, the recompiling of the `module` throws and was not needed at all. In addition to that, next sets a public path, which caused the return value of the module to return the incorrect name of the bundle.

As `entry` in webpack config can be a string, object, a function, we removed it's used and simplified it's use by introducing a `root` option that can be set to the root of an application, defaults to the directory where your webpack.config.js is in. 

Filenames are now correctly processed by the internal compiler.getPath