### PR TITLE
[major] Make puppeteer a somewhat optional dependency

### DIFF
--- a/packages/bundle/README.md
+++ b/packages/bundle/README.md
@@ -31,6 +31,17 @@ The bundle process executes the following steps to produce a bundle:
 npm install --save asset-bundle
 ```
 
+The bundler has an **optional** dependency on `puppeteer`. This module is used
+to resolve the `viewBox` of a given `svg` asset if there is no `viewBox` or
+`height/width` combination available on the asset. If these properties are
+missing on some of your assets you can either manually update them, or install
+`puppeteer` and it will automatically extract the correct viewBox from your
+svg.
+
+```
+npm install --save puppeteer
+```
+
 ## Table of Contents
 
 - [Usage](#usage)

--- a/packages/bundle/dimensions/index.js
+++ b/packages/bundle/dimensions/index.js
@@ -94,12 +94,14 @@ export default function dimensions(svg, fn) {
 
   if (!puppeteer && (root.attr('width') && root.attr('height'))) {
     warning([
+      'file: '+ svg.loc,
+      '',
       'One of the svgs did not have a viewBox property, in order to correctly',
       'calculate this, we need use `puppeteer` for browser based detection.',
       'Please run the following command in the root of application.',
-      ''
-      'npm install --save puppeteer'
-      ''
+      '',
+      'npm install --save puppeteer',
+      '',
       'The bundle process will still continue but the results might be inaccurate'
     ]);
 
@@ -110,12 +112,14 @@ export default function dimensions(svg, fn) {
   }
 
   if (!puppeteer) throw new Error([
+    'file: '+ svg.loc,
+    '',
     'The supplied svg image does not have a `viewBox` or `width/height` combination.',
     'We are unable to extract or create a valid viewBox for this asset without the',
     'installation of `puppeteer`. Please run the following command:',
-    ''
+    '',
     'npm install --save puppeteer',
-    ''
+    '',
     'And run the bundle command again.'
   ].join('\n'))
 

--- a/packages/bundle/dimensions/index.js
+++ b/packages/bundle/dimensions/index.js
@@ -10,19 +10,12 @@ const debug = diagnostics('asset:bundle:dimensions');
  * @private
  */
 function warning(lines) {
-  if (warning.warned) return;
-
   lines.unshift('');    // Extra whitespace at the start.
   lines.push('');       // Extra whitespace at the end.
 
   lines.forEach(function each(line) {
     console.error('asset-bundle:warning', line);
   });
-
-  //
-  // Prevent spamming of multiple error messages.
-  //
-  warning.warned = true;
 }
 
 /**
@@ -98,7 +91,7 @@ export default function dimensions(svg, fn) {
       '',
       'One of the svgs did not have a viewBox property, in order to correctly',
       'calculate this, we need use `puppeteer` for browser based detection.',
-      'Please run the following command in the root of application.',
+      'Please run the following command:',
       '',
       'npm install --save puppeteer',
       '',
@@ -114,14 +107,14 @@ export default function dimensions(svg, fn) {
   if (!puppeteer) throw new Error([
     'file: '+ svg.loc,
     '',
-    'The supplied svg image does not have a `viewBox` or `width/height` combination.',
+    'The supplied svg image does not have a `viewBox` and `width/height` combination.',
     'We are unable to extract or create a valid viewBox for this asset without the',
     'installation of `puppeteer`. Please run the following command:',
     '',
     'npm install --save puppeteer',
     '',
-    'And run the bundle command again.'
-  ].join('\n'))
+    'Or manually fix the svg, and run the bundle command again.'
+  ].join('\n'));
 
   render(svg.data.replace(/<svg[^<]+?>/g, '<svg>'), function (bb) {
     setImmediate(function escapePromiseHell() {

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -19,12 +19,12 @@
     "camel-case": "^3.0.0",
     "cheerio": "^1.0.0-rc.2",
     "diagnostics": "^1.1.0",
-    "puppeteer": "^1.1.0",
     "react": "^16.2.0",
     "svgo": "^1.0.3"
   },
   "devDependencies": {
     "assume": "^1.5.2",
+    "puppeteer": "^1.1.0",
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",


### PR DESCRIPTION
As per title, make puppeteer a somewhat optional dependency. In most, if not all cases, the SVGs that you bundle are already items that you control, and generate, therefor they should have an `viewBox` assigned to them by the editor that saved it. The puppeteer implementation was added to ensure that all svgs that we are given could be handled, but this comes with a hefty 230mb download as result of that decision. 

So this PR does the following:

1. Error to the console when there is, no puppeteer, no viewBox on SVG element, but we do have width/height to somewhat guess a viewBox.
2. **Throw** a hard error when no puppeteer is available, and no width/height combo available.

This will force users to either fix their svgs, or install pupeteer manually as part of their application dependencies. 